### PR TITLE
Separate Endpoint Auth Checks

### DIFF
--- a/internal/api/accounts_test.go
+++ b/internal/api/accounts_test.go
@@ -34,6 +34,7 @@ func TestCreateAccount(t *testing.T) {
 			Description: "Valid Request Body",
 			RequestBody: `{"firstName":"Leagueify","lastName":"Tests","email":"test@leagueify.org","password":"Test123!","dateOfBirth":"1990-08-31","phone":"+12085550000"}`,
 			Mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM accounts").WillReturnRows(sqlmock.NewRows([]string{"id", "first_name", "last_name", "email", "password", "date_of_birth", "coach", "volunteer", "apikey", "is_active", "is_admin"}))
 				mock.ExpectExec("INSERT INTO accounts (.+) VALUES (.+)$").WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			ExpectedStatusCode: http.StatusCreated,
@@ -132,6 +133,7 @@ func TestCreateAccount(t *testing.T) {
 			Description: "Duplicate Email Address",
 			RequestBody: `{"firstName":"Leagueify","lastName":"Tests","email":"test@leagueify.com","password":"Test123!","dateOfBirth":"1990-08-31","phone":"+12085550000"}`,
 			Mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM accounts").WillReturnRows(sqlmock.NewRows([]string{"id", "first_name", "last_name", "email", "password", "date_of_birth", "coach", "volunteer", "apikey", "is_active", "is_admin"}))
 				mock.ExpectExec("^INSERT INTO accounts (.+) VALUES (.+)$").WillReturnError(&pq.Error{Code: "23505", Constraint: "accounts_email_key"})
 			},
 			ExpectedStatusCode: http.StatusBadRequest,
@@ -141,6 +143,7 @@ func TestCreateAccount(t *testing.T) {
 			Description: "Duplicate Phone",
 			RequestBody: `{"firstName":"Leagueify","lastName":"Tests","email":"test@leagueify.com","password":"Test123!","dateOfBirth":"1990-08-31","phone":"+12085550000"}`,
 			Mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM accounts").WillReturnRows(sqlmock.NewRows([]string{"id", "first_name", "last_name", "email", "password", "date_of_birth", "coach", "volunteer", "apikey", "is_active", "is_admin"}))
 				mock.ExpectExec("^INSERT INTO accounts (.+) VALUES (.+)$").WillReturnError(&pq.Error{Code: "23505", Constraint: "accounts_phone_key"})
 			},
 			ExpectedStatusCode: http.StatusBadRequest,
@@ -156,6 +159,7 @@ func TestCreateAccount(t *testing.T) {
 			Description: "Exactly 18 Account Creator",
 			RequestBody: fmt.Sprintf(`{"firstName":"Leagueify","lastName":"Tests","email":"test@leagueify.com","password":"Testu123!","dateOfBirth":"%v","phone":"+12085550000"}`, time.Now().AddDate(-18, 0, 0).Format(time.DateOnly)),
 			Mock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("SELECT \\* FROM accounts").WillReturnRows(sqlmock.NewRows([]string{"id", "first_name", "last_name", "email", "password", "date_of_birth", "coach", "volunteer", "apikey", "is_active", "is_admin"}))
 				mock.ExpectExec("INSERT INTO accounts (.+) VALUES (.+)$").WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			ExpectedStatusCode: http.StatusCreated,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,7 +19,7 @@ type API struct {
 	Validator *validator.Validate
 }
 
-func (api *API) AuthRequired(f func(echo.Context) error) echo.HandlerFunc {
+func (api *API) requiresAuth(f func(echo.Context) error) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		account := model.Account{}
 		apikey := c.Request().Header.Get("apiKey")

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,6 +19,45 @@ type API struct {
 	Validator *validator.Validate
 }
 
+func (api *API) requiresAdmin(f func(echo.Context) error) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		account := model.Account{}
+		apikey := c.Request().Header.Get("apiKey")
+		if !util.VerifyToken(apikey) {
+			return c.JSON(http.StatusUnauthorized,
+				map[string]string{
+					"status": "unauthorized",
+				},
+			)
+		}
+		err := api.DB.QueryRow(`
+			SELECT * FROM accounts where apikey = $1 AND is_active = true AND is_admin = true
+		`, apikey[:len(apikey)-1]).Scan(
+			&account.ID,
+			&account.FirstName,
+			&account.LastName,
+			&account.Email,
+			&account.Password,
+			&account.Phone,
+			&account.DateOfBirth,
+			&account.Coach,
+			&account.Volunteer,
+			&account.APIKey,
+			&account.IsActive,
+			&account.IsAdmin,
+		)
+		api.Account = &account
+		if err != nil {
+			return c.JSON(http.StatusUnauthorized,
+				map[string]string{
+					"status": "unauthorized",
+				},
+			)
+		}
+		return f(c)
+	}
+}
+
 func (api *API) requiresAuth(f func(echo.Context) error) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		account := model.Account{}
@@ -44,6 +83,7 @@ func (api *API) requiresAuth(f func(echo.Context) error) echo.HandlerFunc {
 			&account.Volunteer,
 			&account.APIKey,
 			&account.IsActive,
+			&account.IsAdmin,
 		)
 		api.Account = &account
 		if err != nil {

--- a/internal/api/leagues.go
+++ b/internal/api/leagues.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (api *API) Leagues(e *echo.Group) {
-	e.POST("/leagues", api.AuthRequired(api.createLeague))
+	e.POST("/leagues", api.requiresAdmin(api.createLeague))
 }
 
 func (api *API) createLeague(c echo.Context) error {

--- a/internal/api/positions.go
+++ b/internal/api/positions.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (api *API) Positions(e *echo.Group) {
-	e.GET("/positions", api.AuthRequired(api.listPositions))
+	e.GET("/positions", api.requiresAuth(api.listPositions))
 	e.POST("/positions", api.AuthRequired(api.createPosition))
 }
 

--- a/internal/api/positions.go
+++ b/internal/api/positions.go
@@ -11,7 +11,7 @@ import (
 
 func (api *API) Positions(e *echo.Group) {
 	e.GET("/positions", api.requiresAuth(api.listPositions))
-	e.POST("/positions", api.AuthRequired(api.createPosition))
+	e.POST("/positions", api.requiresAdmin(api.createPosition))
 }
 
 func (api *API) createPosition(c echo.Context) (err error) {

--- a/internal/api/sports.go
+++ b/internal/api/sports.go
@@ -13,7 +13,7 @@ type sport struct {
 }
 
 func (api *API) Sports(e *echo.Group) {
-	e.GET("/sports", api.AuthRequired(api.listSports))
+	e.GET("/sports", api.requiresAuth(api.listSports))
 }
 
 func (api *API) listSports(c echo.Context) (err error) {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -42,7 +42,8 @@ func initAccounts() {
 			coach BOOLEAN DEFAULT false,
 			volunteer BOOLEAN DEFAULT false,
 			apikey TEXT,
-			is_active BOOLEAN DEFAULT false
+			is_active BOOLEAN DEFAULT false,
+			is_admin BOOLEAN DEFAULT false
 		)
 	`)
 	if err != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -41,7 +41,7 @@ func initAccounts() {
 			date_of_birth TEXT NOT NULL,
 			coach BOOLEAN DEFAULT false,
 			volunteer BOOLEAN DEFAULT false,
-			apikey TEXT,
+			apikey TEXT NOT NULL,
 			is_active BOOLEAN DEFAULT false,
 			is_admin BOOLEAN DEFAULT false
 		)

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -13,6 +13,7 @@ type (
 		Volunteer   bool
 		APIKey      string
 		IsActive    bool
+		IsAdmin     bool
 	}
 
 	AccountCreation struct {


### PR DESCRIPTION
**IMPORTANT: PR 1 of 2**

This PR does the following:
 1. Rename `AuthRequired` function to `requiresAuth`
 2. Adds `requiresAdmin` function to auth checks
 3. Sets `is_admin` flag for the first account created
 4. Fixes and Closes #28.

Issue #28 was found when creating multiple accounts. The cause of this was that `apikey` would remain "null" if the account was not validated. The fix was to set the apikey to an empty string when creating the account.